### PR TITLE
Update README, add 2-clause BSD License

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,26 @@
+BSD 2-Clause License
+
+Copyright (c) 2019, Brendon Apo, Francis Arquette, Justin W. Flory, Harrison
+Leong, Elijah Malave, Sem Vladyka.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+RIT NSSA-320 infrastructure (Fall 2019)
+=======================================
+
+[![_License_: 2-clause BSD License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause "2-clause BSD License")
+
+Configuration management for lab assignments in NSSA-320 Configuration Management course at the Rochester Institute of Technology
+
+
+## About
+
+This repo contains configuration management code used for the NSSA-320 Configuration Management course at the Rochester Institute of Technology.
+The project team includes the following people:
+
+* Brendon Apo
+* Francis Arquette
+* Justin W. Flory
+* Harrison Leong
+* Elijah Malave
+* Sem Vladyka
+
+
+## Legal
+
+Per the RIT [Intellectual Property Policy C03.0](https://www.rit.edu/academicaffairs/policiesmanual/c030), this repository is shared under the [2-clause BSD License](https://opensource.org/licenses/BSD-2-Clause).
+The only legal way to reuse this code is including an attribution to the contributors named in the LICENSE.txt.

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,0 @@
-NSSA320 Config Management Group 5 Git Repo
-======================
-***Where we totaly know what we are doing***


### PR DESCRIPTION
This commit adds the 2-clause BSD License to our project. It also adds
in more details to our README if someone / an employer stumbles on this
repo again in the future.