### PR TITLE
Add Ansible boilerplate for project structure

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "centos/7"
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.memory = 4096
+  end
+  # Provisioning configuration for Ansible.
+  config.vm.provision :ansible do |ansible|
+    ansible.compatibility_mode = "2.0"
+    ansible.playbook = "playbooks/local_test.yml"
+  end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory           = inventory/inventory
+roles_path          = roles/

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,0 +1,3 @@
+---
+example_global_var_1: "Global variables exist here"
+example_global_var_2: "These variables can be used in any playbook or role"

--- a/inventory/inventory
+++ b/inventory/inventory
@@ -1,0 +1,12 @@
+[dev]
+127.0.0.1 ansible_connection=local
+
+[centos7]
+
+[centos7:vars]
+ansible_user=ansible_runner
+
+[production]
+
+[staging]
+

--- a/playbooks/local_test.yml
+++ b/playbooks/local_test.yml
@@ -1,0 +1,7 @@
+---
+- name: test playbooks in a local Vagrant virtual machine
+  hosts: dev
+  become: yes
+
+  roles:
+    - base/centos-7


### PR DESCRIPTION
This commit adds the following:

* Vagrantfile: Instruction file to run Vagrant VMs for local testing
* ansible:cfg: Ansible config file
* group_vars/all.yml: Global playbook variables
* inventory: Example inventory file for all hosts
* playbooks/local_test.yml: Playbook to use with testing in Vagrant

This sets up the project to get started on adding more playbooks and
roles. More to come in another PR.