### PR TITLE
Add example roles to use in playbooks

### DIFF
--- a/roles/base/centos-7/tasks/main.yml
+++ b/roles/base/centos-7/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: add/upgrade EPEL and IUS repositories
+  package:
+    state: latest
+    name:
+      - epel-release
+      - https://centos7.iuscommunity.org/ius-release.rpm
+
+- name: install base packages
+  package:
+    state: present
+    name:
+      - certbot
+      - duply
+      - git
+      - htop
+      - python36
+      - python36-pip
+      - yum-plugin-replace
+
+- name: enable SELinux
+  selinux:
+    policy: targeted
+    state: enforcing

--- a/roles/firewalld/tasks/main.yml
+++ b/roles/firewalld/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: install firewalld and fail2ban
+  package:
+    state: present
+    name:
+      - fail2ban
+      - fail2ban-firewalld
+      - firewalld
+
+- name: start/enable firewalld
+  service:
+    name: firewalld
+    state: started
+    enabled: yes

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: install IUS repositories
+  package:
+    state: present
+    name: https://centos7.iuscommunity.org/ius-release.rpm
+
+- name: install MariaDB
+  package:
+    state: present
+    name:
+      - mariadb101u-server
+
+- name: start/enable MariaDB
+  service:
+    name: mariadb
+    state: started
+    enabled: yes

--- a/roles/yum-cron/handlers/main.yml
+++ b/roles/yum-cron/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart yum-cron
+  service:
+    name: yum-cron
+    state: restarted

--- a/roles/yum-cron/tasks/main.yml
+++ b/roles/yum-cron/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: install yum-cron
+  package:
+    state: latest
+    name: yum-cron
+
+- name: configure yum-cron (/etc/yum/yum-cron.conf)
+  template:
+    src: yum-cron.conf
+    dest: /etc/yum/yum-cron.conf
+  notify: restart yum-cron
+
+- name: start/enable yum-cron service
+  service:
+    name: yum-cron
+    state: started
+    enabled: yes

--- a/roles/yum-cron/templates/yum-cron.conf
+++ b/roles/yum-cron/templates/yum-cron.conf
@@ -1,0 +1,88 @@
+###############################################################################
+#                                                                             #
+#           THIS FILE IS MANAGED BY ANSIBLE! CHANGES ARE OVERWRITTEN.         #
+#                   https://github.com/jwflory/infrastructure                 #
+#                                                                             #
+###############################################################################
+
+[commands]
+#  What kind of update to use:
+# default                            = yum upgrade
+# security                           = yum --security upgrade
+# security-severity:Critical         = yum --sec-severity=Critical upgrade
+# minimal                            = yum --bugfix update-minimal
+# minimal-security                   = yum --security update-minimal
+# minimal-security-severity:Critical =  --sec-severity=Critical update-minimal
+update_cmd = security
+
+# Whether a message should be emitted when updates are available,
+# were downloaded, or applied.
+update_messages = yes
+
+# Whether updates should be downloaded when they are available.
+download_updates = yes
+
+# Whether updates should be applied when they are available.  Note
+# that download_updates must also be yes for the update to be applied.
+apply_updates = yes
+
+# Maximum amout of time to randomly sleep, in minutes.  The program
+# will sleep for a random amount of time between 0 and random_sleep
+# minutes before running.  This is useful for e.g. staggering the
+# times that multiple systems will access update servers.  If
+# random_sleep is 0 or negative, the program will run immediately.
+# 6*60 = 360
+random_sleep = 360
+
+
+[emitters]
+# Name to use for this system in messages that are emitted.  If
+# system_name is None, the hostname will be used.
+system_name = {{ ansible_hostname }}
+
+# How to send messages.  Valid options are stdio and email.  If
+# emit_via includes stdio, messages will be sent to stdout; this is useful
+# to have cron send the messages.  If emit_via includes email, this
+# program will send email itself according to the configured options.
+# If emit_via is None or left blank, no messages will be sent.
+emit_via = email
+
+# The width, in characters, that messages that are emitted should be
+# formatted to.
+output_width = 80
+
+
+[email]
+# The address to send email messages from.
+# NOTE: 'localhost' will be replaced with the value of system_name.
+email_from = yum@{{ ansible_hostname }}
+
+# List of addresses to send messages to.
+email_to = jflory7+{{ ansible_hostname }}@gmail.com
+
+# Name of the host to connect to to send email messages.
+email_host = localhost
+
+
+[groups]
+# NOTE: This only works when group_command != objects, which is now the default
+# List of groups to update
+group_list = None
+
+# The types of group packages to install
+group_package_types = mandatory, default
+
+[base]
+# This section overrides yum.conf
+
+# Use this to filter Yum core messages
+# -4: critical
+# -3: critical+errors
+# -2: critical+errors+warnings (default)
+debuglevel = -2
+
+# skip_broken = True
+mdpolicy = group:main
+
+# Uncomment to auto-import new gpg keys (dangerous)
+# assumeyes = True


### PR DESCRIPTION
This commit introduces four new roles to the Ansible config management:

* `base/centos-7`: Misc. changes to CentOS base (e.g. packages)
* `firewalld`: Installs/enables firewall (could also add FW rules later)
* `mariadb`: Installs/enables MySQL server
* `yum-cron`: Installs yum-cron to automatically upgrade security updates

This roles can be used across multiple playbooks, e.g. one for staging
and one for production. A future commit will add an example playbook and
what it might look like.