### PR TITLE
Add playbooks for production host

### DIFF
--- a/playbooks/master.yml
+++ b/playbooks/master.yml
@@ -1,0 +1,2 @@
+---
+- import_playbook: production.yml

--- a/playbooks/production.yml
+++ b/playbooks/production.yml
@@ -1,0 +1,10 @@
+---
+- name: synchronize production host
+  hosts: production
+  become: yes
+
+  roles:
+    - { role: base/centos-7, tags: base }
+    - { role: firewalld, tags: firewalld }
+    - { role: mariadb, tags: mariadb }
+    - { role: yum-cron, tags: yum-cron }


### PR DESCRIPTION
This commit adds two playbooks.

The `master.yml` playbook is the playbook used when running
`ansible-playbook`. It should always import other playbooks intended to
run together at once.

The `production.yml` playbook is an example of how a playbook for our
production host might look. It uses a host group defined in #3 in the
`inventory` file. It uses some of the reusable roles introduced in #4.
Any of those roles can be isolated with the `--tags` flag to
`ansible-playbook`.