### PR TITLE
Add basic CI YAML lint checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: python
+python: "3.6"
+install: "pip install yamllint"
+script: "yamllint -c .yamllint ."

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,4 @@
+extends: relaxed
+
+rules:
+  line-length: disable


### PR DESCRIPTION
This commit adds a Travis CI config combined with a yamllint config
tweaked for Ansible. This change will run tests on new pull requests to
the config management repo to test YAML before it gets merged.