### PR TITLE
inventory: Add production, staging, centos7, and rhel8 hosts

### DIFF
--- a/inventory/inventory
+++ b/inventory/inventory
@@ -1,12 +1,16 @@
 [dev]
 127.0.0.1 ansible_connection=local
 
-[centos7]
-
-[centos7:vars]
-ansible_user=ansible_runner
-
 [production]
+10.0.1.1
 
 [staging]
+10.0.1.2
 
+[centos7]
+10.0.1.1
+10.0.1.2
+10.0.1.3
+
+[rhel8]
+10.0.1.5  # standalone RHEL 8 server to experiment with


### PR DESCRIPTION
This commit adds the hosts on the internal network set up by @leong96.
All hosts belong to one or multiple groups depending on the type of
machine they are.

Once this commit is merged, any playbook that specifies any of these
host groups will work with the correct IP addresses.