### PR TITLE
playbooks: Write a CentOS 7 playbook

### DIFF
--- a/playbooks/centos7.yml
+++ b/playbooks/centos7.yml
@@ -1,10 +1,9 @@
 ---
-- name: synchronize production host
-  hosts: production
+- name: synchronize all CentOS 7 hosts
+  hosts: centos7
   become: yes
 
   roles:
     - { role: base/centos-7, tags: base }
     - { role: firewalld, tags: firewalld }
-    - { role: mariadb, tags: mariadb }
     - { role: yum-cron, tags: yum-cron }

--- a/playbooks/local_test.yml
+++ b/playbooks/local_test.yml
@@ -1,7 +1,0 @@
----
-- name: test playbooks in a local Vagrant virtual machine
-  hosts: dev
-  become: yes
-
-  roles:
-    - base/centos-7

--- a/playbooks/master.yml
+++ b/playbooks/master.yml
@@ -1,2 +1,2 @@
 ---
-- import_playbook: production.yml
+- import_playbook: centos7.yml


### PR DESCRIPTION
This commit reorganizes the playbooks. Instead of a production/staging
playbook (which isn't truly accurate yet since we aren't deploying
anything), I consolidated to a single playbook for all CentOS 7 hosts.

This can be automated as a cron job with the following command:

`ansible-playbook /path/to/rit-nssa-320-infrastructure/playbooks/master.yml`

Some experimentation with what flags are needed for key/password
authentication is likely needed too.