### PR TITLE
Add/webserver role

### DIFF
--- a/roles/california-webserver/files/explorecalifornia.conf
+++ b/roles/california-webserver/files/explorecalifornia.conf
@@ -37,25 +37,18 @@ http {
     include             /etc/nginx/conf.d/*.conf;
 
     server {
-        listen          80;
-        listen          [::]:80;
-        server_name     _;
-        root            /var/www/html;
+        listen          80 default_server;
+        listen          [::]:80 default_server;
+        server_name     explorecalifornia.com www.explorecalifornia.com;
+        root            /var/www/explorecalifornia.com/html;
+        index           index.html index.htm;
 
         include         /etc/nginx/default.d/*.conf;
 
         location / {
-        }
-
-        error_page 404 /404.html;
-            location =  /40x.html {
-        }
-
-        error_page 500 502 503 504 /50x.html;
-            location =  /50x.html {
+            
         }
     }
-
 # Settings for a TLS enabled server.
 #
 #    server {

--- a/roles/california-webserver/handlers/main.yml
+++ b/roles/california-webserver/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart nginx
+  service:
+    name: nginx
+    state: restarted
+    enabled: yes

--- a/roles/california-webserver/tasks/main.yml
+++ b/roles/california-webserver/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: Import global variables
+  include_vars:
+    dir: "{{ inventory_dir }}/group_vars/"
+
+- name: install/upgrade nginx
+  package:
+    name: nginx
+    state: latest
+
+- name: Pull website files from repo to ansible
+  git:
+    repo: https://github.com/BonjeBongo/Explore_California_Website.git
+    dest: "/tmp/"
+    archive: california.zip
+
+- name: Unpack webserver files for nginx to handle
+  unarchive:
+    src: "/tmp/california.zip"
+    dest: "/var/www/explorecalifornia.com/html/"
+    remote_src: yes
+    mode: '0755'
+    group: www-admin
+    owner: www-admin
+    setype: httpd_sys_content_t
+
+- name: get the template in place
+  template:
+    src: "files/explorecalifornia.conf"
+    dest: "/etc/nginx/sites-enabled/explorecalifornia.com"
+    serole: object_r
+    setype: httpd_config_t
+    seuser: system_u
+  notify: restart nginx
+
+- name: start nginx
+  service:
+    name: nginx
+    state: started

--- a/roles/california-webserver/tasks/main.yml
+++ b/roles/california-webserver/tasks/main.yml
@@ -14,6 +14,15 @@
     dest: "/tmp/"
     archive: california.zip
 
+- name: create webserver directory
+  file:
+    path: "/var/www/explorecalifornia.com/html/"
+    state: directory
+    mode: '0755'
+    group: www-admin
+    owner: www-admin
+    setype: httpd_sys_content_t
+
 - name: Unpack webserver files for nginx to handle
   unarchive:
     src: "/tmp/california.zip"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -75,9 +75,9 @@
   loop:
     - 404.html
     - 50x.html
-    # - index.html
-    # - nginx-logo.png
-    # - poweredby.png
+    - index.html
+    - nginx-logo.png
+    - poweredby.png
 
 - name: start nginx
   service:

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -75,9 +75,9 @@
   loop:
     - 404.html
     - 50x.html
-    - index.html
-    - nginx-logo.png
-    - poweredby.png
+    # - index.html
+    # - nginx-logo.png
+    # - poweredby.png
 
 - name: start nginx
   service:


### PR DESCRIPTION
So, this is supposed to do the following:

- pull webserver files from a repo
- push them to the webserver
- make nginx serve up the files

A lot of things were copied from the default nginx.config from nginx role
Not sure how the playbook will use them together or separate but this should do it